### PR TITLE
Add slack deep link to open client

### DIFF
--- a/docs/code.html
+++ b/docs/code.html
@@ -340,7 +340,7 @@
 				<div class="ibm-col-md-6 ibm-col-lg-8">
 					<p class="ibm-type-f ibm-padding-vertical margin-bottom-0 max-width-36">We work hard to make our typography useful and beautiful. Give us feedback to make an improvement or just say hi.</p>
 					<p class="ibm-type-c margin-bottom-0">Leave us a <a href="https://github.com/ibm/type/issues/new">GitHub issue.</a></p>
-					<p class="ibm-type-c margin-bottom-0">IBMers, join the Slack <a href="https://ibm-studios.slack.com/messages/C0U35LB2B/">conversation.</a></p>
+					<p class="ibm-type-c margin-bottom-0">IBMers, join the Slack <a href="slack://channel?team={TEAM_ID}&id={CHANNEL_ID}/">conversation.</a></p>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>

--- a/docs/code.html
+++ b/docs/code.html
@@ -340,7 +340,7 @@
 				<div class="ibm-col-md-6 ibm-col-lg-8">
 					<p class="ibm-type-f ibm-padding-vertical margin-bottom-0 max-width-36">We work hard to make our typography useful and beautiful. Give us feedback to make an improvement or just say hi.</p>
 					<p class="ibm-type-c margin-bottom-0">Leave us a <a href="https://github.com/ibm/type/issues/new">GitHub issue.</a></p>
-					<p class="ibm-type-c margin-bottom-0">IBMers, join the Slack <a href="slack://channel?team={TEAM_ID}&id={CHANNEL_ID}/">conversation.</a></p>
+					<p class="ibm-type-c margin-bottom-0">IBMers, join the Slack <a href="slack://channel?team={ibm-studios}&id={ibm-design-language}/">conversation.</a></p>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>

--- a/docs/code.html
+++ b/docs/code.html
@@ -340,7 +340,7 @@
 				<div class="ibm-col-md-6 ibm-col-lg-8">
 					<p class="ibm-type-f ibm-padding-vertical margin-bottom-0 max-width-36">We work hard to make our typography useful and beautiful. Give us feedback to make an improvement or just say hi.</p>
 					<p class="ibm-type-c margin-bottom-0">Leave us a <a href="https://github.com/ibm/type/issues/new">GitHub issue.</a></p>
-					<p class="ibm-type-c margin-bottom-0">IBMers, join the Slack <a href="slack://channel?team={ibm-studios}&id={ibm-design-language}/">conversation.</a></p>
+					<p class="ibm-type-c margin-bottom-0">IBMers, join the Slack <a href="slack://channel?team=ibm-studios&id=ibm-design-language/">conversation.</a></p>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1337,7 +1337,7 @@
 				<div class="ibm-col-md-6 ibm-col-lg-8">
 					<p class="ibm-type-f ibm-padding-vertical margin-bottom-0 max-width-36">Ask a question, suggest an  improvement, or just say hi.</p>
 					<p class="ibm-type-c margin-bottom-0">Create us a <a href="https://github.com/ibm/type/issues/new">GitHub issue.</a></p>
-					<p class="ibm-type-c margin-bottom-0">IBMers, join the <a href="https://ibm-studios.slack.com/messages/C0U35LB2B/">Slack conversation.</a></p>
+					<p class="ibm-type-c margin-bottom-0">IBMers, join the <a href="slack://channel?team=ibm-studios&id=ibm-design-language/">Slack conversation.</a></p>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>
 					<div class="ibm-padding-vertical"></div>


### PR DESCRIPTION
# Add URI scheme to deep link into Slack client
Code Reference: https://api.slack.com/docs/deep-linking

## PR Content:
- Update URI that includes `TEAM_ID` and `CHANNEL_ID` (This will need to be provided by an "IBMer" with access to that information).
- Link location on page:

 ![screen shot 2017-11-08 at 5 27 31 pm](https://user-images.githubusercontent.com/5695373/32578148-26633c32-c4aa-11e7-95c5-c42ac67c3ce4.png)

- Page: https://ibm.github.io/type/#Type_Color

### Developer Notes:
- I came across this issue https://github.com/IBM/type/issues/38 while participating in Hacktoberfest.
- I am not 100% sure that this is the correct file to make this change within. 
 