### PR TITLE
Add links to GitHub from the webpage for the font

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 					<p class="ibm-type-c">Thanks for your interest in IBM Plex, IBM’s new corporate type family. We welcome your <a target="_blank" rel="noopener noreferrer" href="https://www.github.com/ibm/type/issues/new"></a>feedback and contributions</a> to this project. IBM Plex is open source, and should be used by IBMers for all typographical situations, replacing Helvetica Neue, whenever possible.</p>
 					<p class="ibm-type-c">For all typeface lovers, <a href="https://raw.githubusercontent.com/ibm/type/master/ibm-plex.zip">download IBM Plex here.</a></p>
 					<p class="ibm-type-c">View the up-to-date <a target="_blank" rel="noopener noreferrer" href="http://www.carbondesignsystem.com/style/typography/overview">typography guidelines</a> on the Carbon Design System, IBM’s ever-evolving documentation site for design assets. Plex is one of many elements on Carbon, which also includes iconography, color, components. etc.</p>
+					<p class="ibm-type-c">This type family is licensed under the terms of <a href="https://github.com/IBM/type/blob/master/LICENSE.md">The SIL Open Font License version 1.1 - 26 February 2007</a>.</p>
 				</div>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 			<div class="ibm-col-md-6 ibm-col-lg-7">
 				<div class="ibm-padding-vertical">
 					<h1 class="ibm-type-j">Hello, world.</h1>
-					<p class="ibm-type-c">Thanks for your interest in IBM Plex, IBM’s new corporate type family. We welcome your <a target="_blank" rel="noopener noreferrer" href="https://www.github.com/ibm/type/issues/new"></a>feedback and contributions</a> to this project. IBM Plex is open source, and should be used by IBMers for all typographical situations, replacing Helvetica Neue, whenever possible.</p>
+					<p class="ibm-type-c">Thanks for your interest in IBM Plex, IBM’s new corporate type family. We welcome your <a target="_blank" rel="noopener noreferrer" href="https://www.github.com/ibm/type/issues/new"></a>feedback and contributions</a> to this project. IBM Plex is <a href="https://www.github.com/ibm/type/">open source</a>, and should be used by IBMers for all typographical situations, replacing Helvetica Neue, whenever possible.</p>
 					<p class="ibm-type-c">For all typeface lovers, <a href="https://raw.githubusercontent.com/ibm/type/master/ibm-plex.zip">download IBM Plex here.</a></p>
 					<p class="ibm-type-c">View the up-to-date <a target="_blank" rel="noopener noreferrer" href="http://www.carbondesignsystem.com/style/typography/overview">typography guidelines</a> on the Carbon Design System, IBM’s ever-evolving documentation site for design assets. Plex is one of many elements on Carbon, which also includes iconography, color, components. etc.</p>
 					<p class="ibm-type-c">This type family is licensed under the terms of <a href="https://github.com/IBM/type/blob/master/LICENSE.md">The SIL Open Font License version 1.1 - 26 February 2007</a>.</p>


### PR DESCRIPTION
## Changes:

- Adds the license to `index.html` with a link to LICENSE.md
- Links "open source" to the repository on GitHub

## Why

Because the only links https://ibm.github.io/type/ provides to the GitHub repository are:

1. the new-issues page: https://www.github.com/ibm/type/issues/new
2. a direct link to download a zip of current master: https://raw.githubusercontent.com/ibm/type/master/ibm-plex.zip

And unless someone is familiar with GitHub, they won't be able to easily find the repository's homepage or license.