### PR TITLE
chore(eyeglass): Add eyeglass support to IBM type repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibm/type",
   "description": "The package of IBM’s new typeface, IBM Plex, and accompanying typography code.",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "repository": "https://github.com/ibm/type.git",
   "license": "OFL-1.1 AND Apache-2.0",
   "files": [

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "fonts",
     "scss"
   ],
+  "keywords": [
+    "eyeglass-module"
+  ],
   "bugs": {
     "url": "https://github.com/ibm/type/issues"
   },
@@ -55,5 +58,11 @@
       "prettier",
       "git add"
     ]
+  },
+  "eyeglass": {
+    "exports": false,
+    "name": "ibm-type",
+    "sassDir": "scss",
+    "needs": "^1.3.0"
   }
 }


### PR DESCRIPTION
This issue resolves #128 and provides the following: 

- [ ] Eyeglass support for those that want to import scss files without using a relative path to `node_modules`